### PR TITLE
Update for Godot 4.0.stable, improve demo scene

### DIFF
--- a/CharacterBody3d.gd
+++ b/CharacterBody3d.gd
@@ -9,18 +9,21 @@ var gravity = ProjectSettings.get_setting("physics/3d/default_gravity")
 @onready var camera = $Camera3d
 
 
-func _physics_process(delta):
+func _ready():
+	Input.mouse_mode = Input.MOUSE_MODE_CAPTURED
+
+func _process(delta):
 	# Add the gravity.
 	if not is_on_floor():
 		velocity.y -= gravity * delta
 
 	# Handle Jump.
-	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
+	if Input.is_action_just_pressed("jump") and is_on_floor():
 		velocity.y = JUMP_VELOCITY
 
 	# Get the input direction and handle the movement/deceleration.
 	# As good practice, you should replace UI actions with custom gameplay actions.
-	var input_dir = Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
+	var input_dir = Input.get_vector("move_left", "move_right", "move_forward", "move_backward")
 	var direction = (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
 	if direction:
 		velocity.x = direction.x * SPEED
@@ -30,13 +33,13 @@ func _physics_process(delta):
 		velocity.z = move_toward(velocity.z, 0, SPEED)
 
 	move_and_slide()
-	
+
 	if Input.is_action_just_pressed("ui_cancel"):
 		Input.mouse_mode = Input.MOUSE_MODE_CAPTURED if Input.mouse_mode == Input.MOUSE_MODE_VISIBLE else Input.MOUSE_MODE_VISIBLE
 
 
 func _input(event):
-	if event is InputEventMouseMotion:
+	if event is InputEventMouseMotion and Input.mouse_mode == Input.MOUSE_MODE_CAPTURED:
 		rotate_y(-event.relative.x * look_sensitivity)
 		camera.rotate_x(-event.relative.y * look_sensitivity)
 		camera.rotation.x = clamp(camera.rotation.x, -PI/2, PI/2)

--- a/DemoScene.tscn
+++ b/DemoScene.tscn
@@ -1,21 +1,51 @@
-[gd_scene load_steps=9 format=3 uid="uid://cd7378fcusokl"]
+[gd_scene load_steps=12 format=3 uid="uid://cd7378fcusokl"]
 
 [ext_resource type="Texture2D" uid="uid://dn0ttcbglyr12" path="res://addons/kenney_prototype_textures/purple/texture_05.png" id="1_xcd8s"]
 [ext_resource type="Texture2D" uid="uid://cmvu4oatcl1lr" path="res://addons/kenney_prototype_textures/purple/texture_10.png" id="2_muu8q"]
 [ext_resource type="Script" path="res://CharacterBody3d.gd" id="3_3kw8g"]
 [ext_resource type="PackedScene" uid="uid://fn4ue284pmgv" path="res://motion_blur/motion_blur.tscn" id="4_aoyua"]
 
+[sub_resource type="ProceduralSkyMaterial" id="ProceduralSkyMaterial_f5trw"]
+sky_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
+ground_horizon_color = Color(0.64625, 0.65575, 0.67075, 1)
+
+[sub_resource type="Sky" id="Sky_4kpy4"]
+sky_material = SubResource("ProceduralSkyMaterial_f5trw")
+
+[sub_resource type="Environment" id="Environment_k16iw"]
+background_mode = 2
+sky = SubResource("Sky_4kpy4")
+tonemap_mode = 2
+tonemap_white = 6.0
+
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_sb5qb"]
 albedo_texture = ExtResource("1_xcd8s")
+uv1_triplanar = true
+texture_filter = 5
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_or5xi"]
+albedo_color = Color(1, 4, 1, 1)
 albedo_texture = ExtResource("2_muu8q")
+uv1_triplanar = true
+texture_filter = 5
 
 [sub_resource type="CapsuleMesh" id="CapsuleMesh_1bhqr"]
 
 [sub_resource type="CapsuleShape3D" id="CapsuleShape3D_aoapi"]
 
 [node name="DemoScene" type="Node3D"]
+
+[node name="DirectionalLight3D" type="DirectionalLight3D" parent="."]
+transform = Transform3D(-0.866025, -0.433013, 0.25, 0, 0.5, 0.866025, -0.5, 0.75, -0.433013, 0, 0, 0)
+shadow_enabled = true
+shadow_bias = 0.04
+shadow_blur = 1.5
+directional_shadow_mode = 0
+directional_shadow_fade_start = 1.0
+directional_shadow_max_distance = 20.0
+
+[node name="WorldEnvironment" type="WorldEnvironment" parent="."]
+environment = SubResource("Environment_k16iw")
 
 [node name="CsgCombiner3d" type="CSGCombiner3D" parent="."]
 use_collision = true
@@ -25,6 +55,48 @@ size = Vector3(8, 4, 6)
 material = SubResource("StandardMaterial3D_sb5qb")
 
 [node name="CsgBox3d2" type="CSGBox3D" parent="CsgCombiner3d"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.300376, 0)
+operation = 2
+size = Vector3(7.49306, 4, 6)
+material = SubResource("StandardMaterial3D_or5xi")
+
+[node name="CsgCombiner3d4" type="CSGCombiner3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 6)
+use_collision = true
+
+[node name="CsgBox3d" type="CSGBox3D" parent="CsgCombiner3d4"]
+size = Vector3(8, 4, 6)
+material = SubResource("StandardMaterial3D_sb5qb")
+
+[node name="CsgBox3d2" type="CSGBox3D" parent="CsgCombiner3d4"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.300376, 0)
+operation = 2
+size = Vector3(7.49306, 4, 6)
+material = SubResource("StandardMaterial3D_or5xi")
+
+[node name="CsgCombiner3d2" type="CSGCombiner3D" parent="."]
+transform = Transform3D(-4.37114e-08, 0, -1, 0, 1, 0, 1, 0, -4.37114e-08, 0, -4, -7)
+use_collision = true
+
+[node name="CsgBox3d" type="CSGBox3D" parent="CsgCombiner3d2"]
+size = Vector3(8, 4, 6)
+material = SubResource("StandardMaterial3D_sb5qb")
+
+[node name="CsgBox3d2" type="CSGBox3D" parent="CsgCombiner3d2"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.300376, 0)
+operation = 2
+size = Vector3(7.49306, 4, 6)
+material = SubResource("StandardMaterial3D_or5xi")
+
+[node name="CsgCombiner3d3" type="CSGCombiner3D" parent="."]
+transform = Transform3D(-3.78552e-08, -0.5, -0.866025, -2.18557e-08, 0.866025, -0.5, 1, 0, -4.37114e-08, 6, -4, -6)
+use_collision = true
+
+[node name="CsgBox3d" type="CSGBox3D" parent="CsgCombiner3d3"]
+size = Vector3(8, 4, 6)
+material = SubResource("StandardMaterial3D_sb5qb")
+
+[node name="CsgBox3d2" type="CSGBox3D" parent="CsgCombiner3d3"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.300376, 0)
 operation = 2
 size = Vector3(7.49306, 4, 6)

--- a/addons/kenney_prototype_textures/purple/texture_01.png.import
+++ b/addons/kenney_prototype_textures/purple/texture_01.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/texture_01.png-38f28acdb9a95ea2efd835531b47e5
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/addons/kenney_prototype_textures/purple/texture_02.png.import
+++ b/addons/kenney_prototype_textures/purple/texture_02.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/texture_02.png-fcb52d424cd62d43221e4153fa3176
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/addons/kenney_prototype_textures/purple/texture_03.png.import
+++ b/addons/kenney_prototype_textures/purple/texture_03.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/texture_03.png-10a2d13d96fe9dba00c822080243f0
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/addons/kenney_prototype_textures/purple/texture_04.png.import
+++ b/addons/kenney_prototype_textures/purple/texture_04.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/texture_04.png-6783bd4aa338a51e03fa71a2a0ba6c
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/addons/kenney_prototype_textures/purple/texture_05.png.import
+++ b/addons/kenney_prototype_textures/purple/texture_05.png.import
@@ -4,23 +4,22 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://dn0ttcbglyr12"
 path.s3tc="res://.godot/imported/texture_05.png-888b467a21712cbc594106138f9173b8.s3tc.ctex"
-path.etc2="res://.godot/imported/texture_05.png-888b467a21712cbc594106138f9173b8.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc", "etc2"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://addons/kenney_prototype_textures/purple/texture_05.png"
-dest_files=["res://.godot/imported/texture_05.png-888b467a21712cbc594106138f9173b8.s3tc.ctex", "res://.godot/imported/texture_05.png-888b467a21712cbc594106138f9173b8.etc2.ctex"]
+dest_files=["res://.godot/imported/texture_05.png-888b467a21712cbc594106138f9173b8.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=true

--- a/addons/kenney_prototype_textures/purple/texture_06.png.import
+++ b/addons/kenney_prototype_textures/purple/texture_06.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/texture_06.png-352782bc60b4b3fe4a632b0a6af555
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/addons/kenney_prototype_textures/purple/texture_07.png.import
+++ b/addons/kenney_prototype_textures/purple/texture_07.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/texture_07.png-042b529a59b56931d5b854290aa24a
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/addons/kenney_prototype_textures/purple/texture_08.png.import
+++ b/addons/kenney_prototype_textures/purple/texture_08.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/texture_08.png-ae3e54cc23ad438ea83a8932fe526f
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/addons/kenney_prototype_textures/purple/texture_09.png.import
+++ b/addons/kenney_prototype_textures/purple/texture_09.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/texture_09.png-bfc57ad7b0bd0aecb6d4584eb01976
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/addons/kenney_prototype_textures/purple/texture_10.png.import
+++ b/addons/kenney_prototype_textures/purple/texture_10.png.import
@@ -4,23 +4,22 @@ importer="texture"
 type="CompressedTexture2D"
 uid="uid://cmvu4oatcl1lr"
 path.s3tc="res://.godot/imported/texture_10.png-6ebba9cac53386550299b9fc7ba436fd.s3tc.ctex"
-path.etc2="res://.godot/imported/texture_10.png-6ebba9cac53386550299b9fc7ba436fd.etc2.ctex"
 metadata={
-"imported_formats": ["s3tc", "etc2"],
+"imported_formats": ["s3tc_bptc"],
 "vram_texture": true
 }
 
 [deps]
 
 source_file="res://addons/kenney_prototype_textures/purple/texture_10.png"
-dest_files=["res://.godot/imported/texture_10.png-6ebba9cac53386550299b9fc7ba436fd.s3tc.ctex", "res://.godot/imported/texture_10.png-6ebba9cac53386550299b9fc7ba436fd.etc2.ctex"]
+dest_files=["res://.godot/imported/texture_10.png-6ebba9cac53386550299b9fc7ba436fd.s3tc.ctex"]
 
 [params]
 
 compress/mode=2
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=true

--- a/addons/kenney_prototype_textures/purple/texture_11.png.import
+++ b/addons/kenney_prototype_textures/purple/texture_11.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/texture_11.png-0fd2ee750e7568773caf6d873885f4
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/addons/kenney_prototype_textures/purple/texture_12.png.import
+++ b/addons/kenney_prototype_textures/purple/texture_12.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/texture_12.png-8a7cfbfe5b83f5813249f631484135
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/addons/kenney_prototype_textures/purple/texture_13.png.import
+++ b/addons/kenney_prototype_textures/purple/texture_13.png.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/texture_13.png-ae54826bbb20288cf5ae03de2f2de2
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/icon.svg.import
+++ b/icon.svg.import
@@ -16,9 +16,9 @@ dest_files=["res://.godot/imported/icon.svg-218a8f2b3041327d8a5756f3a245f83b.cte
 [params]
 
 compress/mode=0
+compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1
-compress/bptc_ldr=0
 compress/normal_map=0
 compress/channel_pack=0
 mipmaps/generate=false

--- a/motion_blur/moblur_shader.gdshader
+++ b/motion_blur/moblur_shader.gdshader
@@ -6,10 +6,12 @@ uniform vec3 angular_velocity; //rads
 uniform int iteration_count : hint_range(2, 50);
 uniform float intensity : hint_range(0, 1);
 uniform float startRadius;
+uniform sampler2D screen_texture : hint_screen_texture, filter_linear, repeat_disable;
+uniform sampler2D depth_texture : hint_depth_texture, filter_linear, repeat_disable;
 
 void fragment()
 { 
-	float depth = texture(DEPTH_TEXTURE, SCREEN_UV).r;
+	float depth = texture(depth_texture, SCREEN_UV).r;
 	
 	//Turn the current pixel from ndc to world coordinates
 	vec3 pixel_pos_ndc = vec3(SCREEN_UV*2.0-1.0, depth*2.0-1.0); 
@@ -37,11 +39,11 @@ void fragment()
 		for (int i = 0; i < iteration_count; i++)
 		{
 			vec2 offset = pixel_diff_ndc * (float(i) / float(iteration_count) - 0.5) * intensity; 
-			col += textureLod(SCREEN_TEXTURE, SCREEN_UV + offset,0.0).rgb;
+			col += textureLod(screen_texture, SCREEN_UV + offset,0.0).rgb;
 			counter++;
 		}
 		ALBEDO = col / counter;
 	}
 	else
-		ALBEDO = textureLod(SCREEN_TEXTURE, SCREEN_UV, 0.0).rgb;
+		ALBEDO = textureLod(screen_texture, SCREEN_UV, 0.0).rgb;
 }

--- a/motion_blur/motion_blur.gd
+++ b/motion_blur/motion_blur.gd
@@ -5,30 +5,27 @@ var cam_pos_prev = Vector3()
 var cam_rot_prev = Quaternion()
 
 func _process(_delta):
-	
-	#OS.delay_msec(30)
-	
 	var mat: ShaderMaterial = get_surface_override_material(0)
 	var cam = get_parent()
 	assert(cam is Camera3D)
-	
+
 	# Linear velocity is just difference in positions between two frames.
 	var velocity = cam.global_transform.origin - cam_pos_prev
-	
+
 	# Angular velocity is a little more complicated, as you can see.
 	# See https://math.stackexchange.com/questions/160908/how-to-get-angular-velocity-from-difference-orientation-quaternion-and-time
 	var cam_rot = Quaternion(cam.global_transform.basis)
 	var cam_rot_diff = cam_rot - cam_rot_prev
 	var cam_rot_conj = conjugate(cam_rot)
-	var ang_vel = (cam_rot_diff * 2.0) * cam_rot_conj; 
+	var ang_vel = (cam_rot_diff * 2.0) * cam_rot_conj;
 	ang_vel = Vector3(ang_vel.x, ang_vel.y, ang_vel.z) # Convert Quat to Vector3
-	
+
 	mat.set_shader_parameter("linear_velocity", velocity)
 	mat.set_shader_parameter("angular_velocity", ang_vel)
-		
+
 	cam_pos_prev = cam.global_transform.origin
 	cam_rot_prev = Quaternion(cam.global_transform.basis)
-	
+
 # Calculate the conjugate of a quaternion.
 func conjugate(quat):
 	return Quaternion(-quat.x, -quat.y, -quat.z, quat.w)

--- a/motion_blur/motion_blur.tscn
+++ b/motion_blur/motion_blur.tscn
@@ -9,10 +9,10 @@ size = Vector2(40, 20)
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_h45ax"]
 render_priority = -1
 shader = ExtResource("1_k5wmj")
-shader_parameter/angular_velocity = Vector3(0, 0, 0)
-shader_parameter/intensity = 0.28
-shader_parameter/iteration_count = 15
 shader_parameter/linear_velocity = Vector3(0, 0, 0)
+shader_parameter/angular_velocity = Vector3(0, 0, 0)
+shader_parameter/iteration_count = 15
+shader_parameter/intensity = 0.28
 shader_parameter/startRadius = 0.5
 
 [node name="motion_blur" type="MeshInstance3D"]

--- a/project.godot
+++ b/project.godot
@@ -12,5 +12,43 @@ config_version=5
 
 config/name="Motion Blur"
 run/main_scene="res://DemoScene.tscn"
-config/features=PackedStringArray("4.0", "Vulkan Clustered")
+config/features=PackedStringArray("4.0")
 config/icon="res://icon.svg"
+
+[input]
+
+move_forward={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":87,"key_label":0,"unicode":122,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194320,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+move_backward={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":83,"key_label":0,"unicode":115,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194322,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+move_left={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":65,"key_label":0,"unicode":113,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194319,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+move_right={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":68,"key_label":0,"unicode":100,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194321,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+jump={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
+, Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":2,"pressed":false,"double_click":false,"script":null)
+]
+}
+
+[rendering]
+
+textures/default_filters/anisotropic_filtering_level=4
+anti_aliasing/quality/screen_space_aa=1


### PR DESCRIPTION
- Tweak level for easier previewing of motion blur.
- Tweak graphics settings in the demo for better quality.
- Use physical key inputs so that WASD movement can be used on any keyboard layout.
- Capture mouse input by default in the demo.

___

- This closes https://github.com/davisbrandon02/motion-blur-godot-4.0/issues/2.

## Preview

***Epilepsy warning:** Video contains flashing due to fast camera rotation.*

https://user-images.githubusercontent.com/180032/226503817-38490e73-b87d-40e0-896d-cd5b365ac41a.mp4

